### PR TITLE
ЛР06: исправление синтаксических ошибок

### DIFF
--- a/Labs/06.AXI-Stream/README.md
+++ b/Labs/06.AXI-Stream/README.md
@@ -887,19 +887,19 @@ module task1
   input  logic        rstn_i,
 
   input  logic [15:0] data_a_i,
-  input  logic [15:0] valid_a_i,
+  input  logic        valid_a_i,
   output logic        ready_a_o,
 
   input  logic [15:0] data_b_i,
-  input  logic [15:0] valid_b_i,
+  input  logic        valid_b_i,
   output logic        ready_b_o,
 
   input  logic [15:0] data_c_i,
-  input  logic [15:0] valid_c_i,
+  input  logic        valid_c_i,
   output logic        ready_c_o,
 
   output logic [31:0] data_y_o,
-  output logic [31:0] valid_y_o,
+  output logic        valid_y_o,
   input  logic        ready_y_i
 );
 ...

--- a/Labs/06.AXI-Stream/README.md
+++ b/Labs/06.AXI-Stream/README.md
@@ -968,9 +968,9 @@ module axis_join_param
   input  logic                   clk_i,
   input  logic                   rstn_i,
 
-  input  logic                   s_tvalid [S_NUM-1:0],
-  output logic                   s_tready [S_NUM-1:0],
-  input  logic [TDATA_WIDTH-1:0] s_tdata  [S_NUM-1:0],
+  input  logic                   s_tvalid [SLAVE_NUM-1:0],
+  output logic                   s_tready [SLAVE_NUM-1:0],
+  input  logic [TDATA_WIDTH-1:0] s_tdata  [SLAVE_NUM-1:0],
 
   output logic                   m_tvalid,
   input  logic                   m_tready,


### PR DESCRIPTION
В шапке модуля для задания 1 сигналы valid должны быть однобитными

```verilog
module task1
(
  input  logic        clk_i,
  input  logic        rstn_i,

  input  logic [15:0] data_a_i,
  input  logic [15:0] valid_a_i,
  output logic        ready_a_o,

  input  logic [15:0] data_b_i,
  input  logic [15:0] valid_b_i,
  output logic        ready_b_o,

  input  logic [15:0] data_c_i,
  input  logic [15:0] valid_c_i,
  output logic        ready_c_o,

  output logic [31:0] data_y_o,
  output logic [31:0] valid_y_o,
  input  logic        ready_y_i
);
...
endmodule
```
исправлено на:

```verilog
module task1
(
  input  logic        clk_i,
  input  logic        rstn_i,

  input  logic [15:0] data_a_i,
  input  logic        valid_a_i,
  output logic        ready_a_o,

  input  logic [15:0] data_b_i,
  input  logic        valid_b_i,
  output logic        ready_b_o,

  input  logic [15:0] data_c_i,
  input  logic        valid_c_i,
  output logic        ready_c_o,

  output logic [31:0] data_y_o,
  output logic        valid_y_o,
  input  logic        ready_y_i
);
...
endmodule
```