### PR TITLE
ЛР08: Исправление синтаксических ошибок

### DIFF
--- a/Labs/08. APB and CRC/README.md
+++ b/Labs/08. APB and CRC/README.md
@@ -377,7 +377,7 @@ assign cs = cs_1_ff & (~cs_2_ff);
 always_comb
 begin //Для чтения crc используем адрес 1
   if (cs & (~p_we_i) & (p_adr_i[3:0] == 4'd4))
-    p_dat_o <= {24'd0, crc_o};
+    p_dat_o = {24'd0, crc_o};
 end
 
 // Формирование сигналов на модуль-вычислитель
@@ -503,7 +503,7 @@ module wrapper_crc8
     if (cs & (~p_we_i) & (p_adr_i[3:0] == 4'd4))
       p_dat_o = {24'd0, crc_o};
     else if (cs & (~p_we_i)& (p_adr_i[3:0] == 4'd8))
-      p_dat_o = {24'd0, state};
+      p_dat_o = {30'd0, state};
   end
 
   assign data_valid_i = (cs & p_we_i & p_adr_i[3:0]  == 4'd0);


### PR DESCRIPTION
Исправил в always_comb 
с <= на = 

always_comb
begin //Для чтения crc используем адрес 1
  if (cs & (~p_we_i) & (p_adr_i[3:0] == 4'd4))
    p_dat_o = {24'd0, crc_o};
end

И исправил разрядность 

begin
    p_dat_o = '0;
    if (cs & (~p_we_i) & (p_adr_i[3:0] == 4'd4))
      p_dat_o = {24'd0, crc_o};
    else if (cs & (~p_we_i)& (p_adr_i[3:0] == 4'd8))
      p_dat_o = {30'd0, state};
  end