### PR TITLE
ЛР06: исправление синтаксических ошибок в модуле fifo_wrapper

### DIFF
--- a/Labs/06.AXI-Stream/README.md
+++ b/Labs/06.AXI-Stream/README.md
@@ -344,8 +344,7 @@ module fifo_wrapper
   #(
     .D_WIDTH (8),
     .PTR_WIDTH (4)
-  )
-  (
+  ) i_simple_fifo(
     .clk_i   (clk_i),
     .rstn_i  (rstn_i),
 


### PR DESCRIPTION
Не было имени экземпляра
у подключаемого подмодуля simple_fifo